### PR TITLE
docs: add link to Terraform AWS EKS Module in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The Kubernetes organization is divided into three main directories: `app`, `conf
 
 - [Provision an EKS cluster (AWS)](https://developer.hashicorp.com/terraform/tutorials/kubernetes/eks)
 - [terraform-academy by Douglas (FIAP)](https://github.com/dougls/terraform-academy)
+- [Terraform AWS EKS Module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
This pull request updates the `README.md` file to include an additional resource link for provisioning an EKS cluster on AWS using Terraform.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R158): Added a link to the "Terraform AWS EKS Module" documentation to provide users with an official resource for creating EKS clusters.